### PR TITLE
Many Fixes and Improvements

### DIFF
--- a/RetsConnector/Example.cs
+++ b/RetsConnector/Example.cs
@@ -102,7 +102,7 @@ namespace RetsConnector
 
             // We can also download photos
             // This will return all photos for property with the primarykey 1234
-            IEnumerable<FileObject> files = await Client.GetObject("Property", "Photo", new PhotoId(1234), false);
+            IEnumerable<FileObject> files = await Client.GetObject("Property", "Photo", new PhotoId("1234"), false);
 
             // Here is how we can iterate over the fields
             foreach (FileObject file in files)
@@ -120,11 +120,11 @@ namespace RetsConnector
             }
 
             // you can get a specific image for a given primary key like so
-            IEnumerable<FileObject> files2 = await Client.GetObject("Property", "Photo", new PhotoId(1234, 1), false);
+            IEnumerable<FileObject> files2 = await Client.GetObject("Property", "Photo", new PhotoId("1234", 1), false);
 
 
             // you can get also get images for multiple primary keys at the same time like this
-            List<PhotoId> photoIds = new List<PhotoId>() { new PhotoId(1234), new PhotoId(5678), new PhotoId(2255) };
+            List<PhotoId> photoIds = new List<PhotoId>() { new PhotoId("1234"), new PhotoId("5678"), new PhotoId("2255") };
 
             IEnumerable<FileObject> files3 = await Client.GetObject("Property", "Photo", photoIds, false);
 

--- a/RetsConnector/RetsConnector.csproj
+++ b/RetsConnector/RetsConnector.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
 	<LangVersion>latest</LangVersion>
   </PropertyGroup>
 
@@ -15,12 +15,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RetsSdk/Contracts/IMetadataCollection.cs
+++ b/RetsSdk/Contracts/IMetadataCollection.cs
@@ -1,10 +1,11 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Xml.Linq;
 
 namespace CrestApps.RetsSdk.Contracts
 {
-    public interface IMetadataCollection<T> where T : class
+    public interface IMetadataCollection<T> : IEnumerable<T> where T : class
     {
         void Add(T resource);
         void Remove(T resource);
@@ -14,11 +15,10 @@ namespace CrestApps.RetsSdk.Contracts
         Type GetGenericType();
     }
 
-    public interface IMetadataCollection
+    public interface IMetadataCollection : IEnumerable
     {
         string Version { get; set; }
         DateTime Date { get; set; }
-
     }
 
     public interface IMetadataCollectionLoad

--- a/RetsSdk/Models/Enums/RetsDataType.cs
+++ b/RetsSdk/Models/Enums/RetsDataType.cs
@@ -11,6 +11,7 @@
         Small,
         Int,
         Long,
-        Decimal
+        Decimal,
+        @object
     }
 }

--- a/RetsSdk/Models/FileObject.cs
+++ b/RetsSdk/Models/FileObject.cs
@@ -12,10 +12,11 @@ namespace CrestApps.RetsSdk.Models
         public string ContentDescription { get; set; }
         public string ContentSubDescription { get; set; }
         public Uri ContentLocation { get; set; }
-        public string MemeVersion { get; set; }
+        public string MimeVersion { get; set; }
         public bool IsPreferred { get; set; }
         public string Extension { get; set; }
         public Stream Content { get; set; }
+
         private bool IsDisposed;
 
         public bool IsImage => ContentType?.MediaType.StartsWith("image", StringComparison.CurrentCultureIgnoreCase) ?? false;

--- a/RetsSdk/Models/RetsCollection.cs
+++ b/RetsSdk/Models/RetsCollection.cs
@@ -1,6 +1,7 @@
 ﻿using CrestApps.RetsSdk.Contracts;
 using CrestApps.RetsSdk.Helpers.Extensions;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -14,8 +15,8 @@ namespace CrestApps.RetsSdk.Models
         public string Version { get; set; }
         public DateTime Date { get; set; }
 
-        private List<T> Items = new List<T>();
-        private Type _Type;
+        private readonly List<T> Items = new List<T>();
+        private Type Type;
 
         public void Add(T item)
         {
@@ -34,12 +35,12 @@ namespace CrestApps.RetsSdk.Models
 
         public Type GetGenericType()
         {
-            if (_Type == null)
+            if (Type == null)
             {
-                _Type = typeof(T);
+                Type = typeof(T);
             }
 
-            return _Type;
+            return Type;
         }
 
         public void Remove(T item)
@@ -182,5 +183,14 @@ namespace CrestApps.RetsSdk.Models
         public abstract void Load(XElement xElement);
         public abstract T Get(object value);
 
+        public IEnumerator<T> GetEnumerator()
+        {
+            return Items.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return Items.GetEnumerator();
+        }
     }
 }

--- a/RetsSdk/Models/RetsField.cs
+++ b/RetsSdk/Models/RetsField.cs
@@ -13,7 +13,7 @@ namespace CrestApps.RetsSdk.Models
         public string LongName { get; set; }
         public string DbName { get; set; }
         public string ShortName { get; set; }
-        public int MaximumLength { get; set; }
+        public decimal MaximumLength { get; set; }
         public RetsDataType? DataType { get; set; }
         public int? Precision { get; set; }
         public bool Searchable { get; set; }

--- a/RetsSdk/Models/RetsVersion.cs
+++ b/RetsSdk/Models/RetsVersion.cs
@@ -54,7 +54,7 @@ namespace CrestApps.RetsSdk.Models
 
             var castable = Str.PrependOnce(v, "Version_");
 
-            return Enum.Parse<SupportedRetsVersion>(castable);
+            return (SupportedRetsVersion) Enum.Parse(typeof(SupportedRetsVersion), castable);
         }
 
     }

--- a/RetsSdk/Models/SearchRequest.cs
+++ b/RetsSdk/Models/SearchRequest.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using JetBrains.Annotations;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -9,11 +10,17 @@ namespace CrestApps.RetsSdk.Models
         public string SearchType { get; set; }
         public string Class { get; set; }
         public string QueryType { get; set; } = "DMQL2";
-        public int Count { get; set; } = 0;
+        public CountType Count { get; set; } = CountType.NoCount;
         public string Format { get; set; } = "COMPACT-DECODED"; // COMPACT-DECODED
         public string RestrictedIndicator { get; set; } = "****";
         public int Limit { get; set; } = int.MaxValue;
+        public int Offset { get; set; } = 1;
+        
         public int StandardNames { get; set; } = 0;
+
+        [CanBeNull] 
+        public string RawQuery { get; set; } = null;
+
         public QueryParameterGroup ParameterGroup { get; set; }
         private List<string> Columns = new List<string>();
 
@@ -62,22 +69,42 @@ namespace CrestApps.RetsSdk.Models
             Columns = Columns.Where(x => !columnNames.Contains(x)).ToList();
         }
 
-        public bool HasColumns()
-        {
-            return Columns.Any();
-        }
-
-
+        public bool HasColumns() => Columns.Any();
+        
         public bool HasColumn(string columnName)
         {
-            bool exists = Columns.Any(x => x.Equals(columnName, StringComparison.CurrentCultureIgnoreCase));
-
+            var exists = Columns.Any(x => x.Equals(columnName, StringComparison.CurrentCultureIgnoreCase));
             return exists;
         }
 
-        public IEnumerable<string> GetColumns()
+        public IEnumerable<string> GetColumns() => Columns.Distinct();
+
+        public SearchRequest Clone()
         {
-            return Columns.Distinct();
+            var newSr = new SearchRequest()
+            {
+                SearchType = this.SearchType,
+                Class = this.Class,
+                QueryType = this.QueryType,
+                Count = this.Count,
+                Format = this.Format,
+                RestrictedIndicator = this.RestrictedIndicator,
+                Limit = this.Limit,
+                Offset = this.Offset,
+                StandardNames = this.StandardNames,
+                RawQuery = this.RawQuery,
+                ParameterGroup = this.ParameterGroup,
+            };
+            newSr.AddColumns(this.Columns);
+            return newSr;
         }
     }
+
+    public enum CountType
+    {
+        NoCount = 0,
+        CountWithData = 1,
+        OnlyCount = 2
+    }
+
 }

--- a/RetsSdk/Models/SearchResult.cs
+++ b/RetsSdk/Models/SearchResult.cs
@@ -41,8 +41,6 @@ namespace CrestApps.RetsSdk.Models
                 throw new ArgumentNullException($"{nameof(row)} cannot be null.");
             }
 
-            //return Rows.TryAdd(row.PrimaryKeyValue, row);
-
             if (Rows.ContainsKey(row.PrimaryKeyValue))
             {
                 return false;

--- a/RetsSdk/Models/SearchResult.cs
+++ b/RetsSdk/Models/SearchResult.cs
@@ -6,11 +6,14 @@ namespace CrestApps.RetsSdk.Models
 {
     public class SearchResult
     {
-        public RetsResource Resource { get; private set; }
-        public string ClassName { get; private set; }
+        public RetsResource Resource { get; }
+        public string ClassName { get; }
+
         private string RestrictedValue;
         private string[] Columns { get; set; }
-        private Dictionary<string, SearchResultRow> Rows { get; set; }
+        private Dictionary<string, SearchResultRow> Rows { get; }
+        public bool HasMoreRows { get; internal set; }
+        public int? ServerCount { get; internal set; }
 
         public SearchResult(RetsResource resource, string className, string restrictedValue)
         {
@@ -38,7 +41,17 @@ namespace CrestApps.RetsSdk.Models
                 throw new ArgumentNullException($"{nameof(row)} cannot be null.");
             }
 
-            return Rows.TryAdd(row.PrimaryKeyValue, row);
+            //return Rows.TryAdd(row.PrimaryKeyValue, row);
+
+            if (Rows.ContainsKey(row.PrimaryKeyValue))
+            {
+                return false;
+            }
+            else
+            {
+                Rows.Add(row.PrimaryKeyValue, row);
+                return true;
+            }
         }
 
         public bool RemoveRow(string primaryKeyValue)
@@ -68,7 +81,6 @@ namespace CrestApps.RetsSdk.Models
         public IEnumerable<SearchResultCellValue> Pluck(string columnName)
         {
             var values = Rows.Select(x => x.Value.Get(columnName));
-
             return values;
         }
 
@@ -76,7 +88,6 @@ namespace CrestApps.RetsSdk.Models
             where T : struct
         {
             IEnumerable<T> values = Rows.Select(x => x.Value.Get(columnName).Get<T>());
-
             return values;
         }
 
@@ -84,7 +95,6 @@ namespace CrestApps.RetsSdk.Models
             where T : struct
         {
             IEnumerable<T?> values = Rows.Select(x => x.Value.Get(columnName).GetNullable<T>());
-
             return values;
         }
 
@@ -102,7 +112,6 @@ namespace CrestApps.RetsSdk.Models
         {
             Columns = columns ?? throw new ArgumentNullException($"{nameof(columns)} cannot be null.");
         }
-
 
         public void SetColumns(IEnumerable<string> columns)
         {

--- a/RetsSdk/Models/SearchResultRow.cs
+++ b/RetsSdk/Models/SearchResultRow.cs
@@ -50,7 +50,10 @@ namespace CrestApps.RetsSdk.Models
                 value.SetIsPrimaryKeyValue(keyIndex == index);
                 value.SetIsRestricted(RestrictedValue);
 
-                Values.TryAdd(columns[index].ToLower(), value);
+                if (!Values.ContainsKey(columns[index].ToLower()))
+                {
+                    Values.Add(columns[index].ToLower(), value);
+                }
             }
 
         }

--- a/RetsSdk/Models/SessionResource.cs
+++ b/RetsSdk/Models/SessionResource.cs
@@ -25,8 +25,11 @@ namespace CrestApps.RetsSdk.Models
             {
                 return;
             }
-            
-            Capabilities.TryAdd(name, uri);
+
+            if (!Capabilities.ContainsKey(name))
+            {
+                Capabilities.Add(name, uri);
+            }
         }
 
         public Uri GetCapability(Capability name)

--- a/RetsSdk/RetsSdk.csproj
+++ b/RetsSdk/RetsSdk.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="MimeKit" Version="2.8.0" />
+    <PackageReference Include="MimeKit" Version="3.4.1" />
     <PackageReference Include="MimeTypeMap.Core" Version="1.0.0" />
     <PackageReference Include="X.PagedList" Version="8.4.3" />
   </ItemGroup>

--- a/RetsSdk/RetsSdk.csproj
+++ b/RetsSdk/RetsSdk.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Authors>CrestApps</Authors>
@@ -16,6 +16,7 @@
     <RepositoryUrl>https://github.com/CrestApps/RetsConnector</RepositoryUrl>
     <PackageIconUrl>https://avatars1.githubusercontent.com/u/24724371?s=460&amp;v=4</PackageIconUrl>
     <Version>1.0.1</Version>
+    <Platforms>AnyCPU;x86</Platforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/RetsSdk/RetsSdk.csproj
+++ b/RetsSdk/RetsSdk.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Authors>CrestApps</Authors>

--- a/RetsSdk/Services/IRetsClient.cs
+++ b/RetsSdk/Services/IRetsClient.cs
@@ -8,7 +8,9 @@ namespace CrestApps.RetsSdk.Services
 {
     public interface IRetsClient
     {
-        Task Connect();
+        bool IsConnected { get; }
+
+        Task<bool> Connect();
         Task Disconnect();
 
         Task<SearchResult> Search(SearchRequest request);

--- a/RetsSdk/Services/RetsSession.cs
+++ b/RetsSdk/Services/RetsSession.cs
@@ -53,7 +53,7 @@ namespace CrestApps.RetsSdk.Services
                     XElement element = doc.Descendants(ns + "RETS-RESPONSE").FirstOrDefault()
                     ?? throw new RetsParsingException("Unable to find the RETS-RESPONSE element in the response.");
 
-                    var parts = element.FirstNode.ToString().Split(Environment.NewLine);
+                    var parts = element.FirstNode.ToString().Split(new []{'\r', '\n'});
                     var cookie = response.Headers.GetValues("Set-Cookie").FirstOrDefault();
 
                     return GetRetsResource(parts, cookie);
@@ -132,7 +132,6 @@ namespace CrestApps.RetsSdk.Services
 
             return null;
         }
-
 
         public bool IsStarted()
         {

--- a/RetsSdk/Services/RetsWebRequester.cs
+++ b/RetsSdk/Services/RetsWebRequester.cs
@@ -89,6 +89,10 @@ namespace CrestApps.RetsSdk.Services
                 var credCache = new CredentialCache();
                 credCache.Add(new Uri(Options.LoginUrl), Options.Type.ToString(), new NetworkCredential(Options.Username, Options.Password));
 
+                // The UseCookies and DefaultRequestHeaders.Add("Cookie", ...) have different behavior in net48 and net6.
+                // We need to force UseCookies = false to both have the same expect behavior
+                // See: https://stackoverflow.com/a/13287224
+
                 return new HttpClient(new HttpClientHandler { Credentials = credCache, UseCookies = false });
             }
 

--- a/RetsSdk/Services/RetsWebRequester.cs
+++ b/RetsSdk/Services/RetsWebRequester.cs
@@ -89,7 +89,7 @@ namespace CrestApps.RetsSdk.Services
                 var credCache = new CredentialCache();
                 credCache.Add(new Uri(Options.LoginUrl), Options.Type.ToString(), new NetworkCredential(Options.Username, Options.Password));
 
-                return new HttpClient(new HttpClientHandler { Credentials = credCache });
+                return new HttpClient(new HttpClientHandler { Credentials = credCache, UseCookies = false });
             }
 
             HttpClient client = HttpClientFactory.CreateClient();


### PR DESCRIPTION
- Use netstandard2.0 to be compatible with net48 and netCore.
- Fix Rets Authentication on net48 (`HTTPClient` from net48 and netCore have different behavers)

- Fixes
  - Photo ID can be String by the specification
  - Allow bigger `MaximumLength`
  - Photo Get Object fixes when the server return only one photo result. 
  
- Improvements
  - Request
    - Allow have a RAW rests query, that will be used instead the generated query by the Parameter Group
    - Allow Request have Offset to return the next page of results.
    - Allow Request the result count. (Total Server Count of a Query) (No data, just the number of results will be available)
    - Requests can be cloned.
  - Result 
    - Allow `SearchResult` can tell if more Results available on the server after a result. (Server return paginated results)
    - Allow `SearchResult` return the Total Server Count of a Query. (No data, just the number of results will be available)
 - Client
   - Add `IsConnected` and if the Connection was successful. 

  - Other
    - Implements `IEnumerable` for Library Collections.
    - Add Rests 1.9 version
    - Other improvements
  
- Fix Typo
- Refactor
- Code Format
- Code Clean Up
- Update dependencies
